### PR TITLE
Update wp-cli feature

### DIFF
--- a/checks/textdomain.php
+++ b/checks/textdomain.php
@@ -128,29 +128,32 @@ class TextDomainCheck implements themecheck {
 		if ( !in_array($themename, $this->exceptions) && ! defined( 'WPORGPATH' ) ) {
 			$correct_domain = sanitize_title_with_dashes($data['Name']);
 			if ( $themename != $correct_domain ) {
-				$this->error[] = '<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check' ) . '</span>: ' 
+				$this->error[] = '<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check' ) . '</span>: '
 				. sprintf ( __( "Your theme appears to be in the wrong directory for the theme name. The directory name must match the slug of the theme. This theme's correct slug and text-domain is %s.", 'theme-check' ), '<strong>' . $correct_domain . '</strong>' ).
 				'<br>'. __( '(If this is a child theme, you can ignore this error.)' , 'theme-check' );
 			} elseif ( ! in_array( $correct_domain, $domains ) ) {
-				$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: ' 
+				$this->error[] = '<span class="tc-lead tc-required">' . __( 'REQUIRED', 'theme-check' ) . '</span>: '
 				. sprintf ( __( "This theme text domain does not match the theme's slug. The text domain used: %s", 'theme-check' ), '<strong>' . $domainlist . '</strong>' )
 				. sprintf ( __( "This theme's correct slug and text-domain is %s.", 'theme-check' ), '<strong>' . $correct_domain . '</strong>' );
 				$ret = false;
 			}
 		}
 
-		if ( $domainscount > 1 ) {
-			$this->error[] = '<span class="tc-lead tc-warning">' . __( 'Warning', 'theme-check' ) . '</span>: '
-			. __( 'More than one text-domain is being used in this theme. This means the theme will not be compatible with WordPress.org language packs.', 'theme-check' )
-			. '<br>'
-			. sprintf( __( 'The domains found are %s', 'theme-check'), '<strong>' . $domainlist . '</strong>' );
-		} else {
-			$this->error[] = '<span class="tc-lead tc-info">' . __( 'INFO', 'theme-check' ) . '</span>: '
-			. __( "Only one text-domain is being used in this theme. Make sure it matches the theme's slug correctly so that the theme will be compatible with WordPress.org language packs.", 'theme-check' )
-			. '<br>'
-			. sprintf( __( 'The domain found is %s', 'theme-check'), '<strong>' . $domainlist . '</strong>' );
-
+		// hide from wp-cli 
+		if ( ! defined( 'WP_CLI' ) ) {
+			if ( $domainscount > 1 ) {
+				$this->error[] = '<span class="tc-lead tc-warning">' . __( 'Warning', 'theme-check' ) . '</span>: '
+				. __( 'More than one text-domain is being used in this theme. This means the theme will not be compatible with WordPress.org language packs.', 'theme-check' )
+				. '<br>'
+				. sprintf( __( 'The domains found are %s', 'theme-check'), '<strong>' . $domainlist . '</strong>' );
+			} else {
+				$this->error[] = '<span class="tc-lead tc-info">' . __( 'INFO', 'theme-check' ) . '</span>: '
+				. __( "Only one text-domain is being used in this theme. Make sure it matches the theme's slug correctly so that the theme will be compatible with WordPress.org language packs.", 'theme-check' )
+				. '<br>'
+				. sprintf( __( 'The domain found is %s', 'theme-check'), '<strong>' . $domainlist . '</strong>' );
+			}
 		}
+
 
 		if ( $domainscount > 2 ) {
 			$ret = false;

--- a/readme.txt
+++ b/readme.txt
@@ -56,6 +56,7 @@ If **either** of these two vars are defined a new trac tickbox will appear next 
 == WP CLI Support ==
 * `wp theme review list` to list all themes
 * `wp theme review check <themename>` to review a theme
+* `wp theme review active` to review the active theme
 
 == Changelog ==
 = 20151211.1 =

--- a/readme.txt
+++ b/readme.txt
@@ -57,6 +57,7 @@ If **either** of these two vars are defined a new trac tickbox will appear next 
 * `wp theme review list` to list all themes
 * `wp theme review check <themename>` to review a theme
 * `wp theme review active` to review the active theme
+* `wp theme review check <themename> --format=true` to format output as JSON
 
 == Changelog ==
 = 20151211.1 =

--- a/readme.txt
+++ b/readme.txt
@@ -57,8 +57,8 @@ If **either** of these two vars are defined a new trac tickbox will appear next 
 * `wp theme review list` to list all themes
 * `wp theme review check <themename>` to review a theme
 * `wp theme review active` to review the active theme
+* wp theme review active --format=true` to review the active theme & output as JSON
 * `wp theme review check <themename> --format=true` to format output as JSON
-
 == Changelog ==
 = 20151211.1 =
 * Full sync with Github and all the changes that have happened there.

--- a/theme-check-cli.php
+++ b/theme-check-cli.php
@@ -50,13 +50,6 @@ class ThemeCheckCLI extends WP_CLI_Command {
 	 */
 	public function check( $args = array(), $assoc_args = array() ) {
 
-		// check if format is true
-		if( 'true' == $assoc_args['format'] ) {
-			// WP_CLI::success('Theme Check will format in JSON');
-		} else {
-			// WP_CLI::log('JSON False');
-		}
-
 		global $checkcount, $themechecks;
 
 		// empty array for the json format
@@ -173,12 +166,14 @@ class ThemeCheckCLI extends WP_CLI_Command {
 	/**
 	 * Check for the active theme
 	 *
+	 * [--format=<format>]
+	 * : set to true to format as json. Default: false
+	 *
 	 */
-	public function active(){
+	public function active( $args = array(), $assoc_args = array() ) {
 		$active_theme = wp_get_theme();
 		$theme_folder_name = $active_theme->template;
-		WP_CLI::success('Checking Theme Name: '.$theme_folder_name);
-		$this->check( array($theme_folder_name), array() );
+		$this->check( array($theme_folder_name), $assoc_args);
 	}
 
 }

--- a/theme-check-cli.php
+++ b/theme-check-cli.php
@@ -37,6 +37,7 @@ class ThemeCheckCLI extends WP_CLI_Command {
 			WP_CLI::line( $slug . ': ' . $theme->get('Name') );
 		}
 	}
+
 	/**
 	 * Check a theme
 	 *
@@ -95,7 +96,20 @@ class ThemeCheckCLI extends WP_CLI_Command {
 			WP_CLI::line( WP_CLI::colorize( "%RFail:%n Theme did not pass review." ) );
 		}
 	}
+
+	/**
+	 * Check for the active theme
+	 *
+	 */
+	public function active(){
+		$active_theme = wp_get_theme();
+		$theme_folder_name = $active_theme->template;
+		WP_CLI::success('Checking Theme Name: '.$theme_folder_name);
+		$this->check( array($theme_folder_name), array() );
+	}
+
 }
+
 class ThemeCheckCLILogger extends WP_CLI\Loggers\Regular {
 	public function _line( $message, $label, $color, $handle = STDOUT ) {
 		if ( ! empty( $label ) ) {

--- a/theme-check-cli.php
+++ b/theme-check-cli.php
@@ -64,6 +64,7 @@ class ThemeCheckCLI extends WP_CLI_Command {
 		$warnings_json = array();
 		$reccomended_json = array();
 		$errors_json = array();
+		$result_json = array();
 
 		$theme = $this->fetcher->get_check( $args[0] );
 		$files = $theme->get_files( null, -1 );
@@ -115,32 +116,56 @@ class ThemeCheckCLI extends WP_CLI_Command {
 			} elseif ( 'RECOMMENDED' == trim( $type ) ) {
 				if( 'true' == $assoc_args['format'] ) {
 					array_push($reccomended_json, "Reccommended: ".trim( $message ));
-
 				} else {
 					WP_CLI::warning( '%cRecommended:%n '.trim( $message ) );
 				}
 			} else {
-				WP_CLI::warning( $error );
+				if( 'true' == $assoc_args['format'] ) {
+					array_push($errors_json, "Error: ".trim( $error ));
+				} else {
+					WP_CLI::warning( $error );
+				}
+			}
+		}
+
+
+		WP_CLI::line();
+		if ( empty( $errors ) ){
+			if( 'true' == $assoc_args['format'] ) {
+				array_push($result_json, "Success");
+				array_push($result_json, "Theme passed review.");
+			} else {
+				WP_CLI::success( "Theme passed review." );
+			}
+		} elseif ( true === $pass ){
+			if( 'true' == $assoc_args['format'] ) {
+				array_push($result_json, "Success");
+				array_push($result_json, "Theme passed review with some recommended changes.");
+			} else {
+				WP_CLI::success( "Theme passed review with some recommended changes." );
+			}
+		} else {
+			if( 'true' == $assoc_args['format'] ) {
+				array_push($result_json, "Fail");
+				array_push($result_json, "Theme did not pass review.");
+			} else {
+				WP_CLI::line( WP_CLI::colorize( "%RFail:%n Theme did not pass review." ) );
 			}
 		}
 
 		if( 'true' == $assoc_args['format'] ) {
-			var_dump('required-json');
-			var_dump($required_json);
-			var_dump('reccomended-json');
-			var_dump($reccomended_json);
-			var_dump('warnings-json');
-			var_dump($warnings_json);
+			
+			$output = array (
+				'result' => $result_json,
+				'required' => $required_json,
+				'reccommended' => $reccomended_json,
+				'warnings' => $warnings_json,
+				'errors' => $errors_json
+			);
+
+			echo json_encode($output);
 		}
 
-		WP_CLI::line();
-		if ( empty( $errors ) ){
-			WP_CLI::success( "Theme passed review." );
-		} elseif ( true === $pass ){
-			WP_CLI::success( "Theme passed review with some recommended changes." );
-		} else {
-			WP_CLI::line( WP_CLI::colorize( "%RFail:%n Theme did not pass review." ) );
-		}
 
 
 	}

--- a/theme-check-cli.php
+++ b/theme-check-cli.php
@@ -43,9 +43,28 @@ class ThemeCheckCLI extends WP_CLI_Command {
 	 *
 	 * <theme>
 	 * : The theme slug to check
+	 *
+	 * [--format=<format>]
+	 * : set to true to format as json. Default: false
+	 *
 	 */
-	public function check( $args = array(), $assoc_args = array() ){
+	public function check( $args = array(), $assoc_args = array() ) {
+
+		// check if format is true
+		if( 'true' == $assoc_args['format'] ) {
+			// WP_CLI::success('Theme Check will format in JSON');
+		} else {
+			// WP_CLI::log('JSON False');
+		}
+
 		global $checkcount, $themechecks;
+
+		// empty array for the json format
+		$required_json = array();
+		$warnings_json = array();
+		$reccomended_json = array();
+		$errors_json = array();
+
 		$theme = $this->fetcher->get_check( $args[0] );
 		$files = $theme->get_files( null, -1 );
 		$css = $php = $other = array();
@@ -76,17 +95,44 @@ class ThemeCheckCLI extends WP_CLI_Command {
 		foreach ( $errors as $error ) {
 			list( $type, $message ) = explode( ':', $error, 2 );
 			if ( 'REQUIRED' == trim( $type ) ) {
-				WP_CLI::warning( '%rRequired:%n '.trim( $message ) );
+
+				if( 'true' == $assoc_args['format'] ) {
+					array_push($required_json, "Required: ".trim( $message ));
+				} else {
+					WP_CLI::warning( '%rRequired:%n '.trim( $message ) );
+				}
 				$pass = false;
+
 			} elseif ( 'WARNING' == trim( $type ) ) {
-				WP_CLI::warning( '%yWarning:%n '.trim( $message ) );
+
+				if( 'true' == $assoc_args['format'] ) {
+					array_push($warnings_json, "Warning: ".trim( $message ));
+				} else {
+					WP_CLI::warning( '%yWarning:%n '.trim( $message ) );
+				}
 				$pass = false;
+
 			} elseif ( 'RECOMMENDED' == trim( $type ) ) {
-				WP_CLI::warning( '%cRecommended:%n '.trim( $message ) );
+				if( 'true' == $assoc_args['format'] ) {
+					array_push($reccomended_json, "Reccommended: ".trim( $message ));
+
+				} else {
+					WP_CLI::warning( '%cRecommended:%n '.trim( $message ) );
+				}
 			} else {
 				WP_CLI::warning( $error );
 			}
 		}
+
+		if( 'true' == $assoc_args['format'] ) {
+			var_dump('required-json');
+			var_dump($required_json);
+			var_dump('reccomended-json');
+			var_dump($reccomended_json);
+			var_dump('warnings-json');
+			var_dump($warnings_json);
+		}
+
 		WP_CLI::line();
 		if ( empty( $errors ) ){
 			WP_CLI::success( "Theme passed review." );
@@ -95,6 +141,8 @@ class ThemeCheckCLI extends WP_CLI_Command {
 		} else {
 			WP_CLI::line( WP_CLI::colorize( "%RFail:%n Theme did not pass review." ) );
 		}
+
+
 	}
 
 	/**

--- a/theme-check-cli.php
+++ b/theme-check-cli.php
@@ -154,7 +154,7 @@ class ThemeCheckCLI extends WP_CLI_Command {
 		}
 
 		if( 'true' == $assoc_args['format'] ) {
-			
+
 			$output = array (
 				'result' => $result_json,
 				'required' => $required_json,
@@ -163,7 +163,7 @@ class ThemeCheckCLI extends WP_CLI_Command {
 				'errors' => $errors_json
 			);
 
-			echo json_encode($output);
+			echo htmlspecialchars_decode( json_encode($output, JSON_UNESCAPED_SLASHES ));
 		}
 
 


### PR DESCRIPTION
Update the wp-cli feature to 
- Allow active theme to be checked with one command 
- Allow output to be formatted as JSON
- Hide info notice if used via WP-CLI
- Show raw html/PHP in the JSON output 

(See the readme or wp-cli help for the command usage) 