### PR TITLE
Show theme file name where missing text domain found.

### DIFF
--- a/checks/textdomain.php
+++ b/checks/textdomain.php
@@ -76,7 +76,7 @@ class TextDomainCheck implements themecheck {
 								$new_args[] = $text;
 								$this->error[] = '<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check' ) . '</span>: '
 								. sprintf (
-									__( 'Found a translation function that has an incorrect number of arguments. Function %1$s, with the arguments %2$s', 'theme-check' ),
+									__( 'Found a translation function that is missing a text-domain. Function %1$s, with the arguments %2$s in file: <strong>'.$php_key.'</strong>', 'theme-check' ),
 									'<strong>' . $func . '</strong>',
 									'<strong>' . implode(', ',$new_args) . '</strong>'
 								);


### PR DESCRIPTION
I added ability to see which theme file have problematic missing text domain in code. This is very useful, because this is very common type error in themes files and this is real pain to find this issue in hundreds of theme files without knowing which one you should check for text domain issue.