### PR TITLE
Allow function names ending in `echo` or `print`

### DIFF
--- a/checks/themeforest.php
+++ b/checks/themeforest.php
@@ -44,20 +44,20 @@ class Themeforest implements themecheck {
 		);
 
 		$warn_checks = array(
-			'/@\$/'                                         => esc_html__( 'Possible error suppression is being used', 'theme-check' ),
-			'/@include/'                                    => esc_html__( 'Possible error suppression is being used', 'theme-check' ),
-			'/@require/'                                    => esc_html__( 'Possible error suppression is being used', 'theme-check' ),
-			'/@file/'                                       => esc_html__( 'Possible error suppression is being used', 'theme-check' ),
-			'/[^a-z0-9](?<!_)balanceTags\s?\(\$/'           => esc_html__( 'Possible data validation issues found. balanceTags() does not escape data', 'theme-check' ),
-			'/[^a-z0-9](?<!_)balanceTags\s?\( \$/'          => esc_html__( 'Possible data validation issues found. balanceTags() does not escape data', 'theme-check' ),
-			'/[^a-z0-9](?<!_)force_balance_tags\s?\(\$/'    => esc_html__( 'Possible data validation issues found. force_balance_tags() does not escape data', 'theme-check' ),
-			'/[^a-z0-9](?<!_)force_balance_tags\s?\( \$/'   => esc_html__( 'Possible data validation issues found. force_balance_tags() does not escape data', 'theme-check' ),
-			'/(echo|print)\s*\(?\s*\$/'                     => esc_html__( 'Possible data validation issues found. All dynamic data must be correctly escaped for the context where it is rendered', 'theme-check' ),
-			'/[^a-z0-9](?<!_)\$_SERVER\s?/'                 => esc_html__( 'PHP Global Variable found. Ensure the context is safe and reliable', 'theme-check' ),
-			'/remove_filter\s?\(/'                          => esc_html__( 'Themes should not remove core filters. Ensure this is a valid use case', 'theme-check' ),
-			'/add_meta_boxes/'                              => esc_html__( 'Custom meta box functions are allowed for design only. Ensure this is a valid use case', 'theme-check' ),
-			'/add_meta_box/'                                => esc_html__( 'Custom meta box functions are allowed for design only. Ensure this is a valid use case', 'theme-check' ),
-			'/register_widget\s?\(/'                        => esc_html__( 'Custom widgets are plugin territory', 'theme-check' ),
+			'/@\$/'                                           => esc_html__( 'Possible error suppression is being used', 'theme-check' ),
+			'/@include/'                                      => esc_html__( 'Possible error suppression is being used', 'theme-check' ),
+			'/@require/'                                      => esc_html__( 'Possible error suppression is being used', 'theme-check' ),
+			'/@file/'                                         => esc_html__( 'Possible error suppression is being used', 'theme-check' ),
+			'/[^a-z0-9](?<!_)balanceTags\s?\(\$/'             => esc_html__( 'Possible data validation issues found. balanceTags() does not escape data', 'theme-check' ),
+			'/[^a-z0-9](?<!_)balanceTags\s?\( \$/'            => esc_html__( 'Possible data validation issues found. balanceTags() does not escape data', 'theme-check' ),
+			'/[^a-z0-9](?<!_)force_balance_tags\s?\(\$/'      => esc_html__( 'Possible data validation issues found. force_balance_tags() does not escape data', 'theme-check' ),
+			'/[^a-z0-9](?<!_)force_balance_tags\s?\( \$/'     => esc_html__( 'Possible data validation issues found. force_balance_tags() does not escape data', 'theme-check' ),
+			'/[^a-zA-Z0-9_\x7f-\xff](echo|print)\s*\(?\s*\$/' => esc_html__( 'Possible data validation issues found. All dynamic data must be correctly escaped for the context where it is rendered', 'theme-check' ),
+			'/[^a-z0-9](?<!_)\$_SERVER\s?/'                   => esc_html__( 'PHP Global Variable found. Ensure the context is safe and reliable', 'theme-check' ),
+			'/remove_filter\s?\(/'                            => esc_html__( 'Themes should not remove core filters. Ensure this is a valid use case', 'theme-check' ),
+			'/add_meta_boxes/'                                => esc_html__( 'Custom meta box functions are allowed for design only. Ensure this is a valid use case', 'theme-check' ),
+			'/add_meta_box/'                                  => esc_html__( 'Custom meta box functions are allowed for design only. Ensure this is a valid use case', 'theme-check' ),
+			'/register_widget\s?\(/'                          => esc_html__( 'Custom widgets are plugin territory', 'theme-check' ),
 		);
 
 		$grep = '';


### PR DESCRIPTION
The following regex matches any function name which ends in `print` or `echo`:

https://github.com/envato/envato-theme-check/blob/9b78fcf804c41ec3943d174c7c6afdab84800838/checks/themeforest.php#L55

Please consider changing it to `/[^a-zA-Z0-9_\x7f-\xff](echo|print)\s*\(?\s*\$/`

The regex for matching valid PHP function names is taken from the ["User-defined functions" page in the PHP documentation](https://secure.php.net/manual/en/functions.user-defined.php#example-132)