### PR TITLE
More than one domain false warning fixed.

### DIFF
--- a/checks/textdomain.php
+++ b/checks/textdomain.php
@@ -121,6 +121,9 @@ class TextDomainCheck implements themecheck {
 		}
 
 		$domains = array_unique($domains);
+		// Now, Remove any empty values from array.
+		$domains = array_filter($domains);
+		
 		$domainlist = implode( ', ', $domains );
 		$domainscount = count($domains);
 


### PR DESCRIPTION
There is a bug in the plugin. When it checks the domains then the array_unique function just remove the duplicate values, not the empty ones. So, it is causing the issue and displaying the false warning. Here is the full array before the array_unique plugin applied. https://jmp.sh/4oMlQx5 So, please add a check which also removes the empty values. You can use array_filter after array_unique as i implemented here https://jmp.sh/VZTJNLA