### PR TITLE
Add checks for the legacy API

### DIFF
--- a/checks/themeforest.php
+++ b/checks/themeforest.php
@@ -41,6 +41,7 @@ class Themeforest implements themecheck {
 			'/add_action\( &\$this/'                        => esc_html__( 'When creating a callable, never use &$this, use $this instead', 'theme-check' ),
 			'/admin_bar_menu/'                              => esc_html__( 'Themes must not add any entries to the admin bar', 'theme-check' ),
 			'/create_function\s?\(/'                        => esc_html__( 'The create_function() function has been deprecated as of PHP 7.2.0 and must no longer be used', 'theme-check' ),
+			'/marketplace\.envato\.com/'                    => esc_html__( 'The legacy API at marketplace.envato.com has been retired and must no longer be used', 'theme-check' ),
 		);
 
 		$warn_checks = array(
@@ -58,6 +59,7 @@ class Themeforest implements themecheck {
 			'/add_meta_boxes/'                                => esc_html__( 'Custom meta box functions are allowed for design only. Ensure this is a valid use case', 'theme-check' ),
 			'/add_meta_box/'                                  => esc_html__( 'Custom meta box functions are allowed for design only. Ensure this is a valid use case', 'theme-check' ),
 			'/register_widget\s?\(/'                          => esc_html__( 'Custom widgets are plugin territory', 'theme-check' ),
+			'/\/api_keys\/edit/'                              => esc_html__( 'Likely contains instructions to generate keys for the retired legacy API', 'theme-check' ),
 		);
 
 		$grep = '';


### PR DESCRIPTION
The legacy API is being retired, and we don't want any new themes to use it.

Add two new API-related checks:
- Check for the string `marketplace.envato.com` and throw an error if
found (shouldn't be any need to refer to that domain any longer).

- Check for references to the legacy API key add/edit page at
`/api_keys/edit`, which also should no longer be in use.

I don't really know how to test this (installing it in WP seems to require a `composer.json` file, and my hacked-up version didn't work).  Some docs around how to use this tool would be great :)

/cc @Stephen-Cronin @scottparry @dtbaker @jacobbednarz 