### PR TITLE
Added which file contains the bad code esc_html_e with empty arguments

### DIFF
--- a/checks/textdomain.php
+++ b/checks/textdomain.php
@@ -104,12 +104,22 @@ class TextDomainCheck implements themecheck {
 					--$parens_balance;
 					if ($in_func && 0 == $parens_balance) {
 						if (!$found_domain) {
-							$this->error[] = '<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check' ) . '</span>: '
-							. sprintf (
-								__( 'Found a translation function that is missing a text-domain. Function %1$s, with the arguments %2$s', 'theme-check' ),
-								'<strong>' . $func . '</strong>',
-								'<strong>' . implode(', ',$args) . '</strong>'
-							);
+							$args = implode(', ',$args);
+							if ( empty( $args ) ) {
+								$this->error[] = '<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check' ) . '</span>: '
+								. sprintf (
+									__( 'Found a translation function that is missing a text-domain. Function %1$s, with empty arguments in file: <strong>'. tc_filename( $php_key ) .'</strong>', 'theme-check' ),
+									'<strong>' . $func . '</strong>',
+								);
+							} else {
+								$this->error[] = '<span class="tc-lead tc-warning">' . __( 'WARNING', 'theme-check' ) . '</span>: '
+								. sprintf (
+									__( 'Found a translation function that is missing a text-domain. Function %1$s, with the arguments %2$s', 'theme-check' ),
+									'<strong>' . $func . '</strong>',
+									'<strong>' . $args . '</strong>'
+								);
+							}
+							
 						}
 						$in_func = false;
 						$func='';


### PR DESCRIPTION
Issue: https://github.com/envato/envato-theme-check/issues/64

Please see screenshot for the updated output.

**Before:**
![missingargs](https://user-images.githubusercontent.com/4960876/106713126-f504d800-6634-11eb-8d75-a0caa20c17ef.png)
**After:**
![themecheck-esc_html_e-empty-args-fix](https://user-images.githubusercontent.com/4960876/106713005-c0911c00-6634-11eb-869f-54ef978fff2c.png)

Thanks!
