### PR TITLE
Exclude hidden directories like .git from checking

### DIFF
--- a/checkbase.php
+++ b/checkbase.php
@@ -162,7 +162,14 @@ function tc_trac( $e ) {
 function listdir( $dir ) {
 	$files = array();
 	$dir_iterator = new RecursiveDirectoryIterator( $dir );
-	$iterator = new RecursiveIteratorIterator($dir_iterator, RecursiveIteratorIterator::SELF_FIRST);
+	$filter = new \RecursiveCallbackFilterIterator($dir_iterator, function ($current, $key, $iterator) {
+		// Skip hidden files and directories like .git
+		if ($current->getFilename()[0] === '.') {
+			return false;
+		}
+		return true;
+	});
+	$iterator = new \RecursiveIteratorIterator($filter, RecursiveIteratorIterator::SELF_FIRST);
 
 	foreach ($iterator as $file) {
     	array_push( $files, $file->getPathname() );


### PR DESCRIPTION
This is likely just the beginning of a solution for https://github.com/envato/envato-theme-check/issues/40

While this change does achieve the stated purpose of ignoring the .git folder it has the significant downside of making the check in checks/directories.php pointless. The source control directories that check is looking for have been excluded so they will never be detected. This raises of the possibility of a user unknowingly including their source control directory in their theme.

I am currently unsure how best to provide the user a warning about the presence of a source control directory without including the contents of the source control directory in the list of stuff to be checked.

I have also not yet added anything to meet this part of the issue.

>Would be good to have a list of excluded folders that aren't checked and with a filter we can hook into if we want to include sass folders and anything else that is removed when we run our gulp build.