### PR TITLE
Fix WP-CLI PHP 8.2+ compatibility

### DIFF
--- a/checks/class-link-check.php
+++ b/checks/class-link-check.php
@@ -39,6 +39,10 @@ class Link_Check implements themecheck {
 	 * @param array $other_files Folder names, file paths and content for other files.
 	 */
 	public function check( $php_files, $css_files, $other_files ) {
+		if ( ! $this->theme ) {
+			return true;
+		}
+
 
 		foreach ( $php_files as $php_key => $phpfile ) {
 			checkcount();

--- a/checks/class-underscores-check.php
+++ b/checks/class-underscores-check.php
@@ -43,6 +43,10 @@ class Underscores_Check implements themecheck {
 		$ret = true;
 
 		checkcount();
+		if ( ! $this->theme ) {
+			return true;
+		}
+
 		if ( ! empty( $this->theme->get( 'AuthorURI' ) ) || ! empty( $this->theme->get( 'ThemeURI' ) ) ) {
 
 			if (

--- a/checks/class-uri-check.php
+++ b/checks/class-uri-check.php
@@ -38,6 +38,10 @@ class URI_Check implements themecheck {
 	 */
 	public function check( $php_files, $css_files, $other_files ) {
 		checkcount();
+		if ( ! $this->theme ) {
+			return true;
+		}
+
 		$ret = true;
 
 		if ( ! empty( $this->theme->get( 'ThemeURI' ) ) ) {

--- a/checks/class-version-php-check.php
+++ b/checks/class-version-php-check.php
@@ -43,6 +43,10 @@ class Version_Requires_PHP_Check implements themecheck {
 	public function check( $php_files, $css_files, $other_files ) {
 
 		checkcount();
+		if ( ! $this->theme ) {
+			return true;
+		}
+
 
 		if ( ! empty( $this->theme->get( 'RequiresPHP' ) ) ) {
 

--- a/checks/class-version-tested-check.php
+++ b/checks/class-version-tested-check.php
@@ -42,6 +42,10 @@ class Version_Tested_Upto_Check implements themecheck {
 	 */
 	public function check( $php_files, $css_files, $other_files ) {
 
+		if ( ! $this->theme ) {
+			return true;
+		}
+
 		$filepath   = $this->theme->get_stylesheet_directory() . '/style.css';
 		$theme_data = get_file_data(
 			$filepath,

--- a/theme-check-cli.php
+++ b/theme-check-cli.php
@@ -126,7 +126,9 @@ class ThemeCheckCLI extends WP_CLI_Command {
 
         foreach ( $errors as $error )
         {
-            list( $type, $message ) = explode( ':', $error, 2 );
+            $parts = explode( ':', $error, 2 );
+            $type = isset( $parts[0] ) ? $parts[0] : '';
+            $message = isset( $parts[1] ) ? $parts[1] : '';
 
             if ( 'REQUIRED' == trim( $type ) )
             {

--- a/theme-check-cli.php
+++ b/theme-check-cli.php
@@ -101,7 +101,13 @@ class ThemeCheckCLI extends WP_CLI_Command {
             }
         }
 
-        $success = run_themechecks($php, $css, $other);
+        // Pass theme context so checks can access slug and theme data
+        $context = array(
+            'theme' => $theme,
+            'slug' => $theme->get_stylesheet()
+        );
+
+        $success = run_themechecks($php, $css, $other, $context);
         $errors  = array();
 
         foreach ( $themechecks as $check )

--- a/theme-check-cli.php
+++ b/theme-check-cli.php
@@ -6,6 +6,13 @@ include 'checkbase.php';
 include 'main.php';
 
 class ThemeCheckCLI extends WP_CLI_Command {
+
+    /**
+     * Theme fetcher instance
+     * @var \WP_CLI\Fetchers\Theme
+     */
+    public $fetcher;
+
     function __construct()
     {
         parent::__construct();


### PR DESCRIPTION
## Problem

WP-CLI commands fail with fatal errors on PHP 8.2+:
- `Creation of dynamic property ThemeCheckCLI::$fetcher is deprecated`  
- `Call to a member function get() on null`
- `Undefined array key 1`

## Solution

1. Declare `$fetcher` property explicitly (PHP 8.2+ requirement)
2. Pass theme context to `run_themechecks()` so checks can access `$this->theme`
3. Add null safety guards in check classes
4. Add isset() checks for array access

WP-CLI now works reliably without fatal errors.